### PR TITLE
feat(firstboot): hostname, new user, delete iso-user, ask new disk encryption pw

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ potos_firstboot_ask_keyboardlayout: true
 
 # Sentence to ask user to select a keyboard layout
 potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
+
+# Ask Hostname in an extra popup
+potos_firstboot_ask_hostname: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,4 @@ potos_firstboot_ask_keyboardlayout: true
 potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
 
 # Ask Hostname in an extra popup
-potos_firstboot_ask_hostname: true
+potos_firstboot_ask_hostname: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ potos_firstboot_local_user_add_shell: /bin/bash
 # Not implemented yet:
 ## .iso Image Admin User Handling
 # Delete admin user from .iso install file.
+# Do not delete this admin user, if above no new sudo permissioned user is created ;-)
 potos_firstboot_initial_user_delete_admin_iso_user: true
 
 potos_firstboot_initial_user_change_password: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,8 @@ potos_firstboot_ask_hostname: true
 potos_firstboot_local_user_add_with_sudo: true
 # Ask to create local user, without sudo (admin) rights.
 potos_firstboot_local_user_add_without_sudo: false
+# Define its shell, default is /bin/bash
+potos_firstboot_local_user_add_shell: /bin/bash
 
 # Not implemented yet:
 ## .iso Image Admin User Handling

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ potos_firstboot_ask_hostname: true
 potos_firstboot_local_user_add_with_sudo: true
 # Ask to create local user, without sudo (admin) rights.
 potos_firstboot_local_user_add_without_sudo: false
-# Define its shell, default is /bin/bash
+# Define its shell, we recommend /bin/bash
 potos_firstboot_local_user_add_shell: /bin/bash
 
 ## .iso Image Admin User Handling

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
 potos_firstboot_ask_hostname: true
 
 # to implement in playbook:
-potos_firstboot_initial_user_change_password: false 
+potos_firstboot_initial_user_change_password: false
 potos_firstboot_initial_user_delete_admin_iso_user: false
 potos_firstboot_local_user_add: true
 potos_firstboot_local_user_with_sudo_permission: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,10 @@ potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
 
 # Ask Hostname in an extra popup
 potos_firstboot_ask_hostname: true
+
+# to implement in playbook:
+potos_firstboot_initial_user_change_password: false 
+potos_firstboot_initial_user_delete_admin_iso_user: false
+potos_firstboot_local_user_add: true
+potos_firstboot_local_user_with_sudo_permission: true
+potos_firstboot_local_user_with_sudo_ask_nopass: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,16 @@ potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
 # Ask Hostname in an extra popup
 potos_firstboot_ask_hostname: true
 
-# to implement in playbook:
+## Local User Handling
+# Ask to create a new local user, sudo (admin) rights included
+potos_firstboot_local_user_add_with_sudo: true
+# Ask to create local user, without sudo (admin) rights.
+potos_firstboot_local_user_add_without_sudo: false
+
+# Not implemented yet:
+## .iso Image Admin User Handling
+# Delete admin user from .iso install file.
+potos_firstboot_initial_user_delete_admin_iso_user: true
+
 potos_firstboot_initial_user_change_password: false
-potos_firstboot_initial_user_delete_admin_iso_user: false
-potos_firstboot_local_user_add: true
-potos_firstboot_local_user_with_sudo_permission: true
 potos_firstboot_local_user_with_sudo_ask_nopass: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,4 @@ potos_firstboot_ask_keyboardlayout: true
 potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
 
 # Ask Hostname in an extra popup
-potos_firstboot_ask_hostname: false
+potos_firstboot_ask_hostname: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ potos_firstboot_hostname_script: ''
 potos_firstboot_ask_keyboardlayout: true
 
 # Sentence to ask user to select a keyboard layout
-potos_firstboot_ask_select_keyboardlayout: 'Please select a keyboard layout'
+potos_firstboot_ask_select_keyboardlayout: 'Please select your keyboard layout'
 
 # Ask Hostname in an extra popup
 potos_firstboot_ask_hostname: true
@@ -29,6 +29,9 @@ potos_firstboot_local_user_add_shell: /bin/bash
 # Delete admin user from .iso install file.
 # Do not delete this admin user, if above no new sudo permissioned user is created ;-)
 potos_firstboot_initial_user_delete_admin_iso_user: true
+
+# Ask change disk encryption password
+potos_firstboot_ask_change_disk_enc_pw: true
 
 # Not implemented yet:
 potos_firstboot_initial_user_change_password: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,11 +25,11 @@ potos_firstboot_local_user_add_without_sudo: false
 # Define its shell, default is /bin/bash
 potos_firstboot_local_user_add_shell: /bin/bash
 
-# Not implemented yet:
 ## .iso Image Admin User Handling
 # Delete admin user from .iso install file.
 # Do not delete this admin user, if above no new sudo permissioned user is created ;-)
 potos_firstboot_initial_user_delete_admin_iso_user: true
 
+# Not implemented yet:
 potos_firstboot_initial_user_change_password: false
 potos_firstboot_local_user_with_sudo_ask_nopass: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # Custom commands to execute before the first boot role
 potos_firstboot_precommands: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,15 +19,15 @@
   ansible.builtin.package:
     name: 'yad'
 
-# - name: Ask for keyboard layout
-#   block:
-#     - name: deploy script for keyboard layout selection
-#       ansible.builtin.template:
-#         src: 'change-keyboard-layout.j2'
-#         dest: '/setup/change-keyboard-layout'
-#         mode: '0755'
-#         owner: root
-#         group: root
+- name: Ask for keyboard layout
+  block:
+    - name: deploy script for keyboard layout selection
+      ansible.builtin.template:
+        src: 'change-keyboard-layout.j2'
+        dest: '/setup/change-keyboard-layout.sh'
+        mode: '0755'
+        owner: root
+        group: root
 
 #     - name: ask dialog
 #       ansible.builtin.shell:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,7 +122,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_USER} && ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} ]]; do
+      while [[ -z ${POTOS_NEW_USER} ]] && [[ ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,5 +114,4 @@
 - name: Add local user
   ansible.builtin.user:
     name: "{{ potos_new_user_password.stdout_lines[1] }}"
-    password: "{{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}
-
+    password: "{{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,3 +115,8 @@
   ansible.builtin.user:
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
+
+- name: tmp msg output
+  ansible.builtin.debug:
+    msg: pwdline wrong? register is {{ potos_new_user_password }} and lines {{ potos_new_user_password.stdout_lines }} and lines1 is {{ potos_new_user_password.stdout_lines[1] }} and hashed it is {{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}
+  when: potos_new_user_password is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,30 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: yad --text 'Demo YAD Window that must open during installation'  --button=gtk-close
+
+
+- name: Ask hostname
+  ansible.builtin.shell:
+    executable: '/bin/bash'
+    cmd: |
+      while [[ -z ${POTOS_HOSTNAME} ]]; do
+        USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Hostname' \
+        --borders 20 --align center \
+        --button gtk-ok \
+        --image-on-top --image=/potos-setup/potos.png \
+        --text \
+      "Please enter your hostname below
+      " \
+        --form \
+        --field 'Hostname' \
+      )"
+
+      POTOS_HOSTNAME="$(echo ${USERINPUT} | cut -d '|' -f 1)"
+
+      if [[ -z ${POTOS_HOSTNAME} ]]; then
+        yad --title "${POTOS_CLIENT_NAME} HOSTNAME" \
+          --borders 20 --align center --button gtk-ok --image-on-top \
+          --image=/potos-setup/potos.png \
+          --text 'Please choose the hostname.'
+      fi
+      done

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -223,7 +223,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_LUKS_PW} ]]; do
+      while [[ -z ${POTOS_NEW_LUKS_PW} || -z ${POTOS_NEW_LUKS_PW2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,3 @@
----
-
 - name: Prepare setup directory
   ansible.builtin.file:
     path: '/setup'
@@ -25,14 +23,14 @@
     - name: deploy script for keyboard layout selection
       ansible.builtin.template:
         src: 'change-keyboard-layout.j2'
-        dest: '/setup/change-keyboard-layout'
+        dest: '/setup/change-keyboard-layout2'
         mode: '0755'
         owner: root
         group: root
 
     - name: ask dialog
       ansible.builtin.shell:
-        cmd: '/setup/change-keyboard-layout'
+        cmd: '/setup/change-keyboard-layout2'
       register: potos_firstboot_keyboard_layout
       changed_when: false
 
@@ -60,123 +58,3 @@
         cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
       changed_when: false
       when: potos_firstboot_gsettings_exists.rc == 0
-
-  when: potos_firstboot_ask_keyboardlayout
-
-
-- name: Ask user credentials
-  ansible.builtin.shell:
-    executable: '/bin/bash'
-    cmd: |
-      while [[ -z ${DOMAIN_JOIN_PASS} ]]; do
-        USERINPUT="$(yad --title '{{ potos_fistboot_ask_credentials.title | default("Potos Linux Client Setup") }}' \
-          --borders 20 --fullscreen \
-          --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout" \
-          --image-on-top --image=/setup/potos.png \
-          --text \
-            "{{POTOS_VERSION}} Please enter the password for the domain join user (USER@ad.potos.local) and the Wi-Fi" \
-          --form \
-          --field 'AD join password' \
-          --field 'Wi-Fi password'
-        )"
-        DOMAIN_JOIN_PASS="$(echo ${USERINPUT} | cut -d '|' -f 1)"
-        WIFI_PASS="$(echo ${USERINPUT} | cut -d '|' -f 2)"
-        if [[ -z ${DOMAIN_JOIN_PASS} ]]; then
-          yad --title 'Potos Linux Client Setup' \
-            --borders 20 --center \
-            --button gtk-ok \
-            --image-on-top --image=/setup/potos.png \
-          --text 'Please enter the domain join password!'
-        fi
-        if [[ -z ${WIFI_PASS} ]]; then
-          yad --title 'Potos Linux Client Setup' \
-            --borders 20 --center \
-            --button gtk-ok \
-            --image-on-top --image=/setup/potos.png \
-            --text 'Please enter the Wi-Fi password!'
-        fi
-      done
-      echo $DOMAIN_JOIN_PASS
-      echo $WIFI_PASS
-  register: potos_firstboot_credentials
-  when: potos_firstboot_ask_credentials.enable is defined and potos_firstboot_ask_credentials.enable
-
-- name: Check hostname script
-  ansible.builtin.stat:
-    path: '{{ potos_firstboot_hostname_script }}'
-  register: potos_firstboot_hostname_script_check
-
-- name: Get hostname
-  ansible.builtin.shell:
-    cmd: '{{ potos_firstboot_hostname_script }}'
-  register: potos_firstboot_hostname_script_out
-  when: potos_firstboot_hostname_script_check.stat.exists
-
-- name: Set hostname fact
-  ansible.builtin.set_fact:
-    potos_firstboot_hostname: '{{ potos_firstboot_hostname_script_out.stdout }}'
-  when:
-    - potos_firstboot_hostname_script_check.stat.exists
-    - potos_firstboot_hostname_script_check.rc == 0
-
-- name: Ask for hostname
-  ansible.builtin.shell:
-    executable: '/bin/bash'
-    cmd: |
-      while [[ -z ${HOSTNAME} ]]; do
-        USERINPUT='$(yad --title "Hostname" \
-          --borders 20 --center --button gtk-ok \
-          --form --field "Hostname:"
-        )'
-        HOSTNAME='${echo ${USERINPUT} | cut -d "|" -f 1}}'
-      done
-      echo $HOSTNAME
-  register: potos_firstboot_hostname_dialog
-  when: not potos_firstboot_hostname is defined
-
-- name: Set hostname from dialog
-  ansible.builtin.set_fact:
-    potos_firstbook_hostname: '{{ potos_firstboot_hostname_dialog.stdout }}'
-  when: not potos_firstboot_hostname is defined
-
-- name: Set hostname
-  ansible.builtin.hostname:
-    name: '{{ potos_firstboot_hostname }}'
-  when: potos_firstboot_hostname is defined
-
-- name: Adjust hosts file
-  ansible.builtin.replace:
-    path: '/etc/hosts'
-    regexp: 'potos'
-    replace: '{{ potos_firstboot_hostname }}'
-  when: potos_firstboot_hostname is defined
-
-- name: Update grub config
-  ansible.builtin.replace:
-    path: '/etc/default/grub'
-    regexp: 'GRUB_CMDLINE_LINUX_DEFAULT=.*'
-    replace: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"'
-  tags:
-    - 'molecule-notest'
-
-- name: Write grub entries
-  ansible.builtin.copy:
-    path: '/etc/grub.d/40_custom'
-    content: 'menuentry {{ potos_firstboot_hostname }} { \n echo {{ potos_firstboot_hostname }} \n}'
-  when: potos_firstboot_hostname is defined
-
-- name: Update grub
-  ansible.builtin.shell:
-    cmd: '/usr/sbin/update-grub'
-  tags:
-    - 'molecule-notest'
-
-- name: Post commands
-  ansible.builtin.shell:
-    cmd: '{{ item }}'
-  loop: '{{ potos_firstboot_postcommands }}'
-  when:
-   - potos_firstboot_postcommands is defined
-   - potos_firstboot_postcommands is iterable
-   - potos_firstboot_postcommands is not string
-   - potos_firstboot_postcommands is not mapping

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,6 +134,17 @@
     shell: "{{ potos_firstboot_local_user_add_shell }}"
   when: potos_firstboot_local_user_add_without_sudo == True
 
+- name: Print username from .env
+  cmd: echo ${POTOS_INITIAL_USERNAME}
+  register: potos_firstboot_initial_username
+
+- name: Add local user without sudo permission
+  ansible.builtin.user:
+    name: "{{ potos_firstboot_initial_username.stdout }}"
+    remove: true
+  when: potos_firstboot_initial_user_delete_admin_iso_user == True
+  
+
 # was ok, no debug needed anymore. schroeffu 20221125 1606
 #- name: tmp msg output
 #  ansible.builtin.debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,7 +142,7 @@
 - name: Delete initial local user from env
   ansible.builtin.user:
     name: "{{ potos_firstboot_initial_username.stdout }}"
-    remove: true
+    state: absent
   when: potos_firstboot_initial_user_delete_admin_iso_user == True
   
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
     - name: set keyboard layout in gnome
       ansible.builtin.shell:
-        cmd: "gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'"
+        cmd: gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
       changed_when: false
       when: potos_firstboot_gsettings_exists.rc == 0
   when: potos_firstboot_ask_keyboardlayout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} ]]; do
+      while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} || -z ${POTOS_NEW_PASS2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout" \
@@ -108,7 +108,7 @@
             --image=/setup/potos.png \
             --text 'Please choose and enter your new credentials.'
         fi
-        if [[  ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS_2} ]]; then
+        if [[  ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} ]]; then
           yad --title "${POTOS_CLIENT_NAME} Setup" \
             --borders 20 --align center --button gtk-ok --image-on-top \
             --image=/setup/potos.png \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,12 +22,12 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${HOSTNAME} ]]; do
+      while [[ -z ${POTOS_HOSTNAME} ]]; do
         USERINPUT='$(yad --title "Hostname" \
           --borders 20 --center --button gtk-ok \
           --form --field "Hostname:"
         )'
         HOSTNAME='${echo ${USERINPUT} | cut -d "|" -f 1}}'
       done
-      echo $HOSTNAME
+      echo $POTOS_HOSTNAME
   register: potos_firstboot_hostname_dialog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,11 @@
     executable: '/bin/bash'
     cmd: yad --text 'Demo YAD Window that must open during installation'  --button=gtk-close
 
+- name: Save old hostname
+  ansible.builtin.command:
+    cmd: hostname
+  register: potos_firstboot_old_hostname
+
 - name: Ask hostname
   ansible.builtin.shell:
     executable: '/bin/bash'
@@ -63,18 +68,12 @@
     name: '{{ potos_firstboot_hostname }}'
   when: potos_firstboot_hostname is defined and potos_firstboot_ask_hostname == True
 
-- name: Get the hostname from iso environment var
-  shell: echo "$POTOS_INITIAL_HOSTNAME"
-  register: potos_firstboot_iso_env_hostname
-
-- name: Set old hostname defined from iso as an ansible fact
-  ansible.builtin.set_fact:
-    potos_firstboot_iso_hostname: '{{ potos_firstboot_iso_env_hostname.stdout }}'
-  when: potos_firstboot_iso_env_hostname is defined and potos_firstboot_ask_hostname == True
-
 - name: Adjust hosts file
   ansible.builtin.replace:
     path: '/etc/hosts'
-    regexp: '{{ potos_firstboot_iso_hostname }}'
+    regexp: '{{ potos_firstboot_old_hostname.stdout }}'
     replace: '{{ potos_firstboot_hostname }}'
-  when: potos_firstboot_hostname is defined and potos_firstboot_iso_env_hostname is defined and potos_firstboot_ask_hostname == True
+  when:
+    - potos_firstboot_hostname is defined
+    - potos_firstboot_old_hostname.stdout != ''
+    - potos_firstboot_ask_hostname == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
       " \
           --form \
           --field 'Username' \
-          --field 'Password:H'
+          --field 'Password:H' \
           --field 'Confirm password:H'
         )"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,7 +122,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_USER} ]] && [[ ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} ]]; do
+      while [ ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} -o -z ${POTOS_NEW_USER} ]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \
@@ -223,7 +223,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ ${POTOS_NEW_LUKS_PW} != ${POTOS_NEW_LUKS_PW2} ]]; do
+      while [ ${POTOS_NEW_LUKS_PW} != ${POTOS_NEW_LUKS_PW2} -o -z ${POTOS_NEW_LUKS_PW2} ]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Prepare setup directory
   ansible.builtin.file:
     path: '/setup'
@@ -8,16 +9,16 @@
   ansible.builtin.shell:
     cmd: '{{ item }}'
   loop: '{{ potos_firstboot_precommands }}'
-  when: 
-   - potos_firstboot_precommands is defined
-   - potos_firstboot_precommands is iterable
-   - potos_firstboot_precommands is not string
-   - potos_firstboot_precommands is not mapping
+  when:
+    - potos_firstboot_precommands is defined
+    - potos_firstboot_precommands is iterable
+    - potos_firstboot_precommands is not string
+    - potos_firstboot_precommands is not mapping
 
 - name: Install yad
   ansible.builtin.package:
     name: 'yad'
-    
+
 - name: Yad test
   ansible.builtin.shell:
     executable: '/bin/bash'
@@ -62,11 +63,18 @@
     name: '{{ potos_firstboot_hostname }}'
   when: potos_firstboot_hostname is defined and potos_firstboot_ask_hostname == True
 
+- name: Get the hostname from iso environment var
+  shell: echo "$POTOS_INITIAL_HOSTNAME"
+  register: potos_firstboot_iso_env_hostname
+
+- name: Set old hostname defined from iso as an ansible fact
+  ansible.builtin.set_fact:
+    potos_firstboot_iso_hostname: '{{ potos_firstboot_iso_env_hostname.stdout }}'
+  when: potos_firstboot_iso_env_hostname is defined and potos_firstboot_ask_hostname == True
+
 - name: Adjust hosts file
   ansible.builtin.replace:
     path: '/etc/hosts'
-    regexp: 'potos'
+    regexp: '{{ potos_firstboot_iso_hostname }}'
     replace: '{{ potos_firstboot_hostname }}'
-  when: potos_firstboot_hostname is defined and potos_firstboot_ask_hostname == True
-
-  
+  when: potos_firstboot_hostname is defined and potos_firstboot_iso_env_hostname is defined and potos_firstboot_ask_hostname == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,14 +15,9 @@
     - potos_firstboot_precommands is not string
     - potos_firstboot_precommands is not mapping
 
-- name: Install yad
+- name: Make sure YAD is installed
   ansible.builtin.package:
     name: 'yad'
-
-- name: Yad test
-  ansible.builtin.shell:
-    executable: '/bin/bash'
-    cmd: yad --text 'Demo YAD Window that must open during installation'  --button=gtk-close
 
 - name: Save old hostname
   ansible.builtin.command:
@@ -144,11 +139,3 @@
     name: "{{ potos_firstboot_initial_username.stdout }}"
     state: absent
   when: potos_firstboot_initial_user_delete_admin_iso_user == True
-  
-
-# was ok, no debug needed anymore. schroeffu 20221125 1606
-#- name: tmp msg output
-#  ansible.builtin.debug:
-#    msg: pwdline wrong? register is {{ potos_new_user_password }} and lines {{ potos_new_user_password.stdout_lines }} and lines1 is {{ potos_new_user_password.stdout_lines[1] }} and hashed it is {{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}
-#  when: potos_new_user_password is defined
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,17 +17,8 @@
 - name: Install yad
   ansible.builtin.package:
     name: 'yad'
-
-- name: Ask for hostname
+    
+- name: Yad test
   ansible.builtin.shell:
     executable: '/bin/bash'
-    cmd: |
-      while [[ -z ${POTOS_HOSTNAME} ]]; do
-        USERINPUT='$(yad --title "Hostname" \
-          --borders 20 --center --button gtk-ok \
-          --form --field "Hostname:"
-        )'
-        HOSTNAME='${echo ${USERINPUT} | cut -d "|" -f 1}}'
-      done
-      echo $POTOS_HOSTNAME
-  register: potos_firstboot_hostname_dialog
+    cmd: yad --text 'Demo YAD Window that must open during installation'  --button=gtk-close

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,7 +138,7 @@
   ansible.builtin.command: echo ${POTOS_INITIAL_USERNAME}
   register: potos_firstboot_initial_username
 
-- name: Add local user without sudo permission
+- name: Delete initial local user from env
   ansible.builtin.user:
     name: "{{ potos_firstboot_initial_username.stdout }}"
     remove: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,37 +29,37 @@
         owner: root
         group: root
 
-     - name: ask dialog
-       ansible.builtin.shell:
-         cmd: '/setup/change-keyboard-layout.sh'
-       register: potos_firstboot_keyboard_layout
-       changed_when: false
+    - name: ask dialog
+      ansible.builtin.shell:
+        cmd: '/setup/change-keyboard-layout.sh'
+      register: potos_firstboot_keyboard_layout
+      changed_when: false
 
-     - name: check if keyboard file exists
-       ansible.builtin.stat:
-         path: '/etc/default/keyboard'
-       register: potos_firstboot_default_keyboard_stat
+    - name: check if keyboard file exists
+      ansible.builtin.stat:
+        path: '/etc/default/keyboard'
+      register: potos_firstboot_default_keyboard_stat
 
-     - name: set keyboard layout
-       ansible.builtin.replace:
-         path: '/etc/default/keyboard'
-         regexp: 'XKBLAYOUT="\w*"'
-         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
-       when: potos_firstboot_default_keyboard_stat.stat.exists
+    - name: set keyboard layout
+      ansible.builtin.replace:
+        path: '/etc/default/keyboard'
+        regexp: 'XKBLAYOUT="\w*"'
+        replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
+      when: potos_firstboot_default_keyboard_stat.stat.exists
 
-     - name: check if gsettings is installed
-       ansible.builtin.shell:
-         cmd: 'gsettings help'
-       failed_when: false
-       changed_when: false
-       register: potos_firstboot_gsettings_exists
+    - name: check if gsettings is installed
+      ansible.builtin.shell:
+        cmd: 'gsettings help'
+      failed_when: false
+      changed_when: false
+      register: potos_firstboot_gsettings_exists
 
-     - name: set keyboard layout in gnome
-       ansible.builtin.shell:
-         cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
-       changed_when: false
-       when: potos_firstboot_gsettings_exists.rc == 0
-   when: potos_firstboot_ask_keyboardlayout
+    - name: set keyboard layout in gnome
+      ansible.builtin.shell:
+        cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
+      changed_when: false
+      when: potos_firstboot_gsettings_exists.rc == 0
+  when: potos_firstboot_ask_keyboardlayout
 
 - name: Save old hostname
   ansible.builtin.command:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,7 +122,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} || -z ${POTOS_NEW_PASS2} ]]; do
+      while [[ -z ${POTOS_NEW_USER} && ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \
@@ -223,7 +223,7 @@
   ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
-      while [[ -z ${POTOS_NEW_LUKS_PW} || -z ${POTOS_NEW_LUKS_PW2} ]]; do
+      while [[ ${POTOS_NEW_LUKS_PW} != ${POTOS_NEW_LUKS_PW2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
           --button gtk-ok \
@@ -269,7 +269,7 @@
     executable: '/bin/bash'
     cmd: |
       eval "$(awk '/crypt/ {print $2}' /etc/crypttab)" && LUKS_DEVICE="$(realpath "/dev/disk/by-uuid/${UUID}")"
-      printf '%s\n' '{{ potos_old_luks_password.stdout }} ' "{{ potos_new_luks_password.stdout }}" | cryptsetup luksChangeKey "${LUKS_DEVICE}" -q
+      printf '%s\n' '{{ potos_old_luks_password.stdout }}' "{{ potos_new_luks_password.stdout }}" | cryptsetup luksChangeKey "${LUKS_DEVICE}" -q
       if [[ $? -ne 0 ]]; then
         echo "# Failed to change primary disk encryption key"
         exit 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
 
     - name: set keyboard layout in gnome
       ansible.builtin.shell:
+        executable: '/bin/bash'
         cmd: gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
       changed_when: false
       when: potos_firstboot_gsettings_exists.rc == 0
@@ -122,7 +123,7 @@
       while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} || -z ${POTOS_NEW_PASS2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
-          --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout" \
+          --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout.sh" \
           --image-on-top --image=/setup/potos.png \
           --text \
       "IMPORTANT: If your password contains special characters, please remember to select the appropriate keyboard layout first.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,37 +29,37 @@
         owner: root
         group: root
 
-#     - name: ask dialog
-#       ansible.builtin.shell:
-#         cmd: '/setup/change-keyboard-layout'
-#       register: potos_firstboot_keyboard_layout
-#       changed_when: false
+     - name: ask dialog
+       ansible.builtin.shell:
+         cmd: '/setup/change-keyboard-layout.sh'
+       register: potos_firstboot_keyboard_layout
+       changed_when: false
 
-#     - name: check if keyboard file exists
-#       ansible.builtin.stat:
-#         path: '/etc/default/keyboard'
-#       register: potos_firstboot_default_keyboard_stat
+     - name: check if keyboard file exists
+       ansible.builtin.stat:
+         path: '/etc/default/keyboard'
+       register: potos_firstboot_default_keyboard_stat
 
-#     - name: set keyboard layout
-#       ansible.builtin.replace:
-#         path: '/etc/default/keyboard'
-#         regexp: 'XKBLAYOUT="\w*"'
-#         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
-#       when: potos_firstboot_default_keyboard_stat.stat.exists
+     - name: set keyboard layout
+       ansible.builtin.replace:
+         path: '/etc/default/keyboard'
+         regexp: 'XKBLAYOUT="\w*"'
+         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
+       when: potos_firstboot_default_keyboard_stat.stat.exists
 
-#     - name: check if gsettings is installed
-#       ansible.builtin.shell:
-#         cmd: 'gsettings help'
-#       failed_when: false
-#       changed_when: false
-#       register: potos_firstboot_gsettings_exists
+     - name: check if gsettings is installed
+       ansible.builtin.shell:
+         cmd: 'gsettings help'
+       failed_when: false
+       changed_when: false
+       register: potos_firstboot_gsettings_exists
 
-#     - name: set keyboard layout in gnome
-#       ansible.builtin.shell:
-#         cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
-#       changed_when: false
-#       when: potos_firstboot_gsettings_exists.rc == 0
-#   when: potos_firstboot_ask_keyboardlayout
+     - name: set keyboard layout in gnome
+       ansible.builtin.shell:
+         cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
+       changed_when: false
+       when: potos_firstboot_gsettings_exists.rc == 0
+   when: potos_firstboot_ask_keyboardlayout
 
 - name: Save old hostname
   ansible.builtin.command:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,8 +113,6 @@
 
 - name: Add local user
   ansible.builtin.user:
-    name: {{ potos_new_user_password.stdout_lines[1] }}
-    password: {{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}
-    #comment: {{ potos_firstboot_local_user_add_comment_yad.stdout_lines[:3] }}
-    #group: sudo
+    name: "{{ potos_new_user_password.stdout_lines[1] }}"
+    password: "{{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     - name: set keyboard layout
       ansible.builtin.replace:
         path: '/etc/default/keyboard'
-        regexp: 'XKBLAYOUT="\w*"'
+        regexp: 'XKBLAYOUT=.*'
         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
       when: potos_firstboot_default_keyboard_stat.stat.exists
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,16 +95,24 @@
           --form \
           --field 'Username' \
           --field 'Password:H'
+          --field 'Confirm password:H'
         )"
 
         POTOS_NEW_USER="$(echo ${USERINPUT} | cut -d '|' -f 1)"
         POTOS_NEW_PASS="$(echo ${USERINPUT} | cut -d '|' -f 2)"
+        POTOS_NEW_PASS2="$(echo ${USERINPUT} | cut -d '|' -f 3)"
 
         if [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} ]]; then
           yad --title "${POTOS_CLIENT_NAME} Setup" \
             --borders 20 --align center --button gtk-ok --image-on-top \
             --image=/setup/potos.png \
             --text 'Please choose and enter your new credentials.'
+        fi
+        if [[  ${POTOS_NEW_PASS} != ${POTOS_NEW_PASS_2} ]]; then
+          yad --title "${POTOS_CLIENT_NAME} Setup" \
+            --borders 20 --align center --button gtk-ok --image-on-top \
+            --image=/setup/potos.png \
+            --text 'Your password was not identical. Please try again.'
         fi
       done
       echo $POTOS_NEW_USER
@@ -116,7 +124,9 @@
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
 
-- name: tmp msg output
-  ansible.builtin.debug:
-    msg: pwdline wrong? register is {{ potos_new_user_password }} and lines {{ potos_new_user_password.stdout_lines }} and lines1 is {{ potos_new_user_password.stdout_lines[1] }} and hashed it is {{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}
-  when: potos_new_user_password is defined
+# was ok, no debug needed anymore. schroeffu 20221125 1606
+#- name: tmp msg output
+#  ansible.builtin.debug:
+#    msg: pwdline wrong? register is {{ potos_new_user_password }} and lines {{ potos_new_user_password.stdout_lines }} and lines1 is {{ potos_new_user_password.stdout_lines[1] }} and hashed it is {{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}
+#  when: potos_new_user_password is defined
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Hostname' \
         --borders 20 --align center \
         --button gtk-ok \
-        --image-on-top --image=/potos-setup/potos.png \
+        --image-on-top --image=/setup/potos.png \
         --text \
       "Please enter your hostname below
       " \
@@ -77,3 +77,44 @@
     - potos_firstboot_hostname is defined
     - potos_firstboot_old_hostname.stdout != ''
     - potos_firstboot_ask_hostname == True
+
+- name: Ask new user
+  ansible.builtin.shell:
+    executable: '/bin/bash'
+    cmd: |
+      while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} ]]; do
+        USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
+          --borders 20 --align center \
+          --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout" \
+          --image-on-top --image=/setup/potos.png \
+          --text \
+      "IMPORTANT: If your password contains special characters, please remember to select the appropriate keyboard layout first.
+
+      Please enter your new credentials below 
+      " \
+          --form \
+          --field 'Username' \
+          --field 'Password:H'
+        )"
+
+        POTOS_NEW_USER="$(echo ${USERINPUT} | cut -d '|' -f 1)"
+        POTOS_NEW_PASS="$(echo ${USERINPUT} | cut -d '|' -f 2)"
+
+        if [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} ]]; then
+          yad --title "${POTOS_CLIENT_NAME} Setup" \
+            --borders 20 --align center --button gtk-ok --image-on-top \
+            --image=/setup/potos.png \
+            --text 'Please choose and enter your new credentials.'
+        fi
+      done
+      echo $POTOS_NEW_USER
+      echo $POTOS_NEW_PASS
+  register: potos_new_user_password
+
+- name: Add local user
+  ansible.builtin.user:
+    name: {{ potos_new_user_password.stdout_lines[1] }}
+    password: {{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}
+    #comment: {{ potos_firstboot_local_user_add_comment_yad.stdout_lines[:3] }}
+    #group: sudo
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,6 @@
     executable: '/bin/bash'
     cmd: yad --text 'Demo YAD Window that must open during installation'  --button=gtk-close
 
-
 - name: Ask hostname
   ansible.builtin.shell:
     executable: '/bin/bash'
@@ -49,4 +48,25 @@
           --text 'Please choose the hostname.'
       fi
       done
+      echo $POTOS_HOSTNAME
+  register: potos_firstboot_hostname_dialog
   when: potos_firstboot_ask_hostname == True
+
+- name: Set hostname from dialog as an ansible fact
+  ansible.builtin.set_fact:
+    potos_firstboot_hostname: '{{ potos_firstboot_hostname_dialog.stdout }}'
+  when: potos_firstboot_hostname is undefined and potos_firstboot_ask_hostname == True
+
+- name: Set hostname
+  ansible.builtin.hostname:
+    name: '{{ potos_firstboot_hostname }}'
+  when: potos_firstboot_hostname is defined and potos_firstboot_ask_hostname == True
+
+- name: Adjust hosts file
+  ansible.builtin.replace:
+    path: '/etc/hosts'
+    regexp: 'potos'
+    replace: '{{ potos_firstboot_hostname }}'
+  when: potos_firstboot_hostname is defined and potos_firstboot_ask_hostname == True
+
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
     - name: set keyboard layout in gnome
       ansible.builtin.shell:
-        cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
+        cmd: "gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'"
       changed_when: false
       when: potos_firstboot_gsettings_exists.rc == 0
   when: potos_firstboot_ask_keyboardlayout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,48 +19,49 @@
   ansible.builtin.package:
     name: 'yad'
 
-- name: Ask for keyboard layout
-  block:
-    - name: deploy script for keyboard layout selection
-      ansible.builtin.template:
-        src: 'change-keyboard-layout.j2'
-        dest: '/setup/change-keyboard-layout.sh'
-        mode: '0755'
-        owner: root
-        group: root
+# - name: Ask for keyboard layout
+#   block:
+#     - name: deploy script for keyboard layout selection
+#       ansible.builtin.template:
+#         src: 'change-keyboard-layout.j2'
+#         dest: '/setup/change-keyboard-layout.sh'
+#         mode: '0755'
+#         owner: root
+#         group: root
 
-    - name: ask dialog
-      ansible.builtin.shell:
-        cmd: '/setup/change-keyboard-layout.sh'
-      register: potos_firstboot_keyboard_layout
-      changed_when: false
+#     - name: ask dialog
+#       ansible.builtin.shell:
+#         cmd: '/setup/change-keyboard-layout.sh'
+#       register: potos_firstboot_keyboard_layout
+#       changed_when: false
 
-    - name: check if keyboard file exists
-      ansible.builtin.stat:
-        path: '/etc/default/keyboard'
-      register: potos_firstboot_default_keyboard_stat
+#     - name: check if keyboard file exists
+#       ansible.builtin.stat:
+#         path: '/etc/default/keyboard'
+#       register: potos_firstboot_default_keyboard_stat
 
-    - name: set keyboard layout
-      ansible.builtin.replace:
-        path: '/etc/default/keyboard'
-        regexp: 'XKBLAYOUT=.*'
-        replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
-      when: potos_firstboot_default_keyboard_stat.stat.exists
+#     - name: set keyboard layout
+#       ansible.builtin.replace:
+#         path: '/etc/default/keyboard'
+#         regexp: 'XKBLAYOUT=.*'
+#         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
+#       when: potos_firstboot_default_keyboard_stat.stat.exists
 
-    - name: check if gsettings is installed
-      ansible.builtin.shell:
-        cmd: 'gsettings help'
-      failed_when: false
-      changed_when: false
-      register: potos_firstboot_gsettings_exists
+#     - name: check if gsettings is installed
+#       ansible.builtin.shell:
+#         cmd: 'gsettings help'
+#       failed_when: false
+#       changed_when: false
+#       register: potos_firstboot_gsettings_exists
 
-    - name: set keyboard layout in gnome
-      ansible.builtin.shell:
-        executable: '/bin/bash'
-        cmd: rm -rf ~/.cache/dconf && rm -rf ~/.dbus && gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
-      changed_when: false
-      when: potos_firstboot_gsettings_exists.rc == 0
-  when: potos_firstboot_ask_keyboardlayout
+#     - name: set keyboard layout in gnome
+#       ansible.builtin.shell:
+#         executable: '/bin/bash'
+#         cmd: gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
+#       changed_when: false
+#       when: potos_firstboot_gsettings_exists.rc == 0
+#   when: potos_firstboot_ask_keyboardlayout
+### Error "(process:4037): dconf-WARNING **: 19:01:19.683: failed to commit changes to dconf: The connection is closed", isn't it runnung as user gnome-initial-setup?
 
 - name: Save old hostname
   ansible.builtin.command:
@@ -75,9 +76,10 @@
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Hostname' \
         --borders 20 --align center \
         --button gtk-ok \
+        --button "Change keyboard layout":"/setup/change-keyboard-layout.sh" \
         --image-on-top --image=/setup/potos.png \
         --text \
-      "Please enter your hostname below
+      "Please enter your hostname below.
       " \
         --form \
         --field 'Hostname' \
@@ -123,7 +125,8 @@
       while [[ -z ${POTOS_NEW_USER} || -z ${POTOS_NEW_PASS} || -z ${POTOS_NEW_PASS2} ]]; do
         USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
           --borders 20 --align center \
-          --button gtk-ok --button "Change keyboard layout":"/setup/change-keyboard-layout.sh" \
+          --button gtk-ok \
+          --button "Change keyboard layout":"/setup/change-keyboard-layout.sh" \
           --image-on-top --image=/setup/potos.png \
           --text \
       "IMPORTANT: If your password contains special characters, please remember to select the appropriate keyboard layout first.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -219,6 +219,62 @@
 #   tags:
 #     - 'molecule-notest'
 
+- name: Ask new disk encryption password
+  ansible.builtin.shell:
+    executable: '/bin/bash'
+    cmd: |
+      while [[ -z ${POTOS_NEW_LUKS_PW} ]]; do
+        USERINPUT="$(yad --fullscreen --title '${POTOS_CLIENT_NAME} Setup' \
+          --borders 20 --align center \
+          --button gtk-ok \
+          --button "Change keyboard layout":"/setup/change-keyboard-layout.sh" \
+          --image-on-top --image=/setup/potos.png \
+          --text \
+      "Your disk encryption password needs to be changed now, because the default password is unsecure.
+
+      IMPORTANT: Do not forget your disk encryption boot password! Please note your disk encryption boot password on a very safe plase.
+
+      Please enter your new disk encryption password below
+      " \
+          --form \
+          --field 'Password:H' \
+          --field 'Confirm password:H'
+        )"
+
+        POTOS_NEW_LUKS_PW="$(echo ${USERINPUT} | cut -d '|' -f 1)"
+        POTOS_NEW_LUKS_PW2="$(echo ${USERINPUT} | cut -d '|' -f 2)"
+
+        if [[ -z ${POTOS_NEW_LUKS_PW} ]]; then
+          yad --title "${POTOS_CLIENT_NAME} Setup" \
+            --borders 20 --align center --button gtk-ok --image-on-top \
+            --image=/setup/potos.png \
+            --text 'Please choose and enter your new credentials.'
+        fi
+        if [[  ${POTOS_NEW_LUKS_PW} != ${POTOS_NEW_LUKS_PW2} ]]; then
+          yad --title "${POTOS_CLIENT_NAME} Setup" \
+            --borders 20 --align center --button gtk-ok --image-on-top \
+            --image=/setup/potos.png \
+            --text 'Your password was not identical. Please try again.'
+        fi
+      done
+      echo $POTOS_NEW_LUKS_PW
+  register: potos_new_luks_password
+
+- name: Print old luks pw from env
+  ansible.builtin.shell: . /setup/.env && echo ${POTOS_DISK_ENCRYPTION_INITIAL_PASSWORD}
+  register: potos_old_luks_password
+
+- name: Change boot disk encryption luks password now
+  ansible.builtin.command:
+    executable: '/bin/bash'
+    cmd: |
+      eval "$(awk '/crypt/ {print $2}' /etc/crypttab)" && LUKS_DEVICE="$(realpath "/dev/disk/by-uuid/${UUID}")"
+      printf '%s\n' 'install' "{{ potos_old_luks_password.stdout }}" | cryptsetup luksChangeKey "${LUKS_DEVICE}" -q
+      if [[ $? -ne 0 ]]; then
+        echo "# Failed to change primary disk encryption key"
+        exit 1
+      fi
+
 - name: Post commands
   ansible.builtin.shell:
     cmd: '{{ item }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,7 +135,7 @@
   when: potos_firstboot_local_user_add_without_sudo == True
 
 - name: Print username from env
-  ansible.builtin.command: echo ${POTOS_INITIAL_USERNAME}
+  ansible.builtin.command: . /setup/.env && echo ${POTOS_INITIAL_USERNAME}
   register: potos_firstboot_initial_username
 
 - name: Delete initial local user from env

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,8 +134,8 @@
     shell: "{{ potos_firstboot_local_user_add_shell }}"
   when: potos_firstboot_local_user_add_without_sudo == True
 
-- name: Print username from .env
-  cmd: echo ${POTOS_INITIAL_USERNAME}
+- name: Print username from env
+  ansible.builtin.command: echo ${POTOS_INITIAL_USERNAME}
   register: potos_firstboot_initial_username
 
 - name: Add local user without sudo permission

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,9 +135,10 @@
   when: potos_firstboot_local_user_add_without_sudo == True
 
 - name: Print username from env
-  ansible.builtin.command: . /setup/.env && echo ${POTOS_INITIAL_USERNAME}
+  ansible.builtin.shell: source /setup/.env && echo ${POTOS_INITIAL_USERNAME}
   register: potos_firstboot_initial_username
-
+  when: potos_firstboot_initial_user_delete_admin_iso_user == True
+  
 - name: Delete initial local user from env
   ansible.builtin.user:
     name: "{{ potos_firstboot_initial_username.stdout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,12 +124,14 @@
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
     groups: sudo
+    shell: "{{ potos_firstboot_local_user_add_shell }}"
   when: potos_firstboot_local_user_add_with_sudo == True
 
 - name: Add local user without sudo permission
   ansible.builtin.user:
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
+    shell: "{{ potos_firstboot_local_user_add_shell }}"
   when: potos_firstboot_local_user_add_without_sudo == True
 
 # was ok, no debug needed anymore. schroeffu 20221125 1606

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -259,10 +259,12 @@
       done
       echo $POTOS_NEW_LUKS_PW
   register: potos_new_luks_password
+  when: potos_firstboot_ask_change_disk_enc_pw
 
 - name: Print old luks pw from env
   ansible.builtin.shell: . /setup/.env && echo ${POTOS_DISK_ENCRYPTION_INITIAL_PASSWORD}
   register: potos_old_luks_password
+  when: potos_firstboot_ask_change_disk_enc_pw
 
 - name: Change boot disk encryption luks password now
   ansible.builtin.shell:
@@ -274,6 +276,7 @@
         echo "# Failed to change primary disk encryption key"
         exit 1
       fi
+  when: potos_firstboot_ask_change_disk_enc_pw
 
 - name: Post commands
   ansible.builtin.shell:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,3 +49,4 @@
           --text 'Please choose the hostname.'
       fi
       done
+  when: potos_firstboot_ask_hostname == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,43 +18,16 @@
   ansible.builtin.package:
     name: 'yad'
 
-- name: Ask for keyboard layout
-  block:
-    - name: deploy script for keyboard layout selection
-      ansible.builtin.template:
-        src: 'change-keyboard-layout.j2'
-        dest: '/setup/change-keyboard-layout2'
-        mode: '0755'
-        owner: root
-        group: root
-
-    - name: ask dialog
-      ansible.builtin.shell:
-        cmd: '/setup/change-keyboard-layout2'
-      register: potos_firstboot_keyboard_layout
-      changed_when: false
-
-    - name: check if keyboard file exists
-      ansible.builtin.stat:
-        path: '/etc/default/keyboard'
-      register: potos_firstboot_default_keyboard_stat
-    
-    - name: set keyboard layout
-      ansible.builtin.replace:
-        path: '/etc/default/keyboard'
-        regexp: 'XKBLAYOUT="\w*"'
-        replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
-      when: potos_firstboot_default_keyboard_stat.stat.exists
-
-    - name: check if gsettings is installed
-      ansible.builtin.shell:
-        cmd: 'gsettings help'
-      failed_when: false
-      changed_when: false
-      register: potos_firstboot_gsettings_exists
-
-    - name: set keyboard layout in gnome
-      ansible.builtin.shell:
-        cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
-      changed_when: false
-      when: potos_firstboot_gsettings_exists.rc == 0
+- name: Ask for hostname
+  ansible.builtin.shell:
+    executable: '/bin/bash'
+    cmd: |
+      while [[ -z ${HOSTNAME} ]]; do
+        USERINPUT='$(yad --title "Hostname" \
+          --borders 20 --center --button gtk-ok \
+          --form --field "Hostname:"
+        )'
+        HOSTNAME='${echo ${USERINPUT} | cut -d "|" -f 1}}'
+      done
+      echo $HOSTNAME
+  register: potos_firstboot_hostname_dialog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,7 +90,7 @@
           --text \
       "IMPORTANT: If your password contains special characters, please remember to select the appropriate keyboard layout first.
 
-      Please enter your new credentials below 
+      Please enter your new credentials below
       " \
           --form \
           --field 'Username' \
@@ -113,5 +113,5 @@
 
 - name: Add local user
   ansible.builtin.user:
-    name: "{{ potos_new_user_password.stdout_lines[1] }}"
-    password: "{{ potos_new_user_password.stdout_lines[2] | password_hash('sha512') }}"
+    name: "{{ potos_new_user_password.stdout_lines[0] }}"
+    password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,10 +135,10 @@
   when: potos_firstboot_local_user_add_without_sudo == True
 
 - name: Print username from env
-  ansible.builtin.shell: source /setup/.env && echo ${POTOS_INITIAL_USERNAME}
+  ansible.builtin.shell: . /setup/.env && echo ${POTOS_INITIAL_USERNAME}
   register: potos_firstboot_initial_username
   when: potos_firstboot_initial_user_delete_admin_iso_user == True
-  
+
 - name: Delete initial local user from env
   ansible.builtin.user:
     name: "{{ potos_firstboot_initial_username.stdout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,48 @@
   ansible.builtin.package:
     name: 'yad'
 
+# - name: Ask for keyboard layout
+#   block:
+#     - name: deploy script for keyboard layout selection
+#       ansible.builtin.template:
+#         src: 'change-keyboard-layout.j2'
+#         dest: '/setup/change-keyboard-layout'
+#         mode: '0755'
+#         owner: root
+#         group: root
+
+#     - name: ask dialog
+#       ansible.builtin.shell:
+#         cmd: '/setup/change-keyboard-layout'
+#       register: potos_firstboot_keyboard_layout
+#       changed_when: false
+
+#     - name: check if keyboard file exists
+#       ansible.builtin.stat:
+#         path: '/etc/default/keyboard'
+#       register: potos_firstboot_default_keyboard_stat
+
+#     - name: set keyboard layout
+#       ansible.builtin.replace:
+#         path: '/etc/default/keyboard'
+#         regexp: 'XKBLAYOUT="\w*"'
+#         replace: 'XKBLAYOUT="{{ potos_firstboot_keyboard_layout.stdout }}"'
+#       when: potos_firstboot_default_keyboard_stat.stat.exists
+
+#     - name: check if gsettings is installed
+#       ansible.builtin.shell:
+#         cmd: 'gsettings help'
+#       failed_when: false
+#       changed_when: false
+#       register: potos_firstboot_gsettings_exists
+
+#     - name: set keyboard layout in gnome
+#       ansible.builtin.shell:
+#         cmd: "gsettings set org.gnome.desktop.input-sources sources '[(\"xkb\", \"{{ potos_firstboot_keyboard_layout.stdout }}\")]'"
+#       changed_when: false
+#       when: potos_firstboot_gsettings_exists.rc == 0
+#   when: potos_firstboot_ask_keyboardlayout
+
 - name: Save old hostname
   ansible.builtin.command:
     cmd: hostname
@@ -139,3 +181,46 @@
     name: "{{ potos_firstboot_initial_username.stdout }}"
     state: absent
   when: potos_firstboot_initial_user_delete_admin_iso_user == True
+
+# - name: Check hostname script
+#   ansible.builtin.stat:
+#     path: '{{ potos_firstboot_hostname_script }}'
+#   register: potos_firstboot_hostname_script_check
+
+# - name: Get hostname
+#   ansible.builtin.shell:
+#     cmd: '{{ potos_firstboot_hostname_script }}'
+#     register: potos_firstboot_hostname_script_out
+#   when: potos_firstboot_hostname_script_check.stat.exists
+
+## Grub replace is in finish.sh in the .iso, we will move that into this playbook later on.
+
+# - name: Update grub config
+#   ansible.builtin.replace:
+#     path: '/etc/default/grub'
+#     regexp: 'GRUB_CMDLINE_LINUX_DEFAULT=.*'
+#     replace: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"'
+#   tags:
+#     - 'molecule-notest'
+
+# - name: Write grub entries
+#   ansible.builtin.copy:
+#     path: '/etc/grub.d/40_custom'
+#     content: 'menuentry {{ potos_firstboot_hostname }} { \n echo {{ potos_firstboot_hostname }} \n}'
+#   when: potos_firstboot_hostname is defined
+
+# - name: Update grub
+#   ansible.builtin.shell:
+#     cmd: '/usr/sbin/update-grub'
+#   tags:
+#     - 'molecule-notest'
+
+- name: Post commands
+  ansible.builtin.shell:
+    cmd: '{{ item }}'
+  loop: '{{ potos_firstboot_postcommands }}'
+  when:
+    - potos_firstboot_postcommands is defined
+    - potos_firstboot_postcommands is iterable
+    - potos_firstboot_postcommands is not string
+    - potos_firstboot_postcommands is not mapping

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
     - name: set keyboard layout in gnome
       ansible.builtin.shell:
         executable: '/bin/bash'
-        cmd: gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
+        cmd: rm -rf ~/.cache/dconf && rm -rf ~/.dbus && gsettings set org.gnome.desktop.input-sources sources '[("xkb", "{{ potos_firstboot_keyboard_layout.stdout }}")]'
       changed_when: false
       when: potos_firstboot_gsettings_exists.rc == 0
   when: potos_firstboot_ask_keyboardlayout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -269,7 +269,7 @@
     executable: '/bin/bash'
     cmd: |
       eval "$(awk '/crypt/ {print $2}' /etc/crypttab)" && LUKS_DEVICE="$(realpath "/dev/disk/by-uuid/${UUID}")"
-      printf '%s\n' 'install' "{{ potos_old_luks_password.stdout }}" | cryptsetup luksChangeKey "${LUKS_DEVICE}" -q
+      printf '%s\n' '{{ potos_old_luks_password.stdout }} ' "{{ potos_new_luks_password.stdout }}" | cryptsetup luksChangeKey "${LUKS_DEVICE}" -q
       if [[ $? -ne 0 ]]; then
         echo "# Failed to change primary disk encryption key"
         exit 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -265,7 +265,7 @@
   register: potos_old_luks_password
 
 - name: Change boot disk encryption luks password now
-  ansible.builtin.command:
+  ansible.builtin.shell:
     executable: '/bin/bash'
     cmd: |
       eval "$(awk '/crypt/ {print $2}' /etc/crypttab)" && LUKS_DEVICE="$(realpath "/dev/disk/by-uuid/${UUID}")"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,10 +119,18 @@
       echo $POTOS_NEW_PASS
   register: potos_new_user_password
 
-- name: Add local user
+- name: Add local user with sudo permission
   ansible.builtin.user:
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
+    groups: sudo
+  when: potos_firstboot_local_user_add_with_sudo == True
+
+- name: Add local user without sudo permission
+  ansible.builtin.user:
+    name: "{{ potos_new_user_password.stdout_lines[0] }}"
+    password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
+  when: potos_firstboot_local_user_add_without_sudo == True
 
 # was ok, no debug needed anymore. schroeffu 20221125 1606
 #- name: tmp msg output

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -10,7 +10,7 @@ done)
 KEYBOARD_LAYOUT="$(yad --width 600 --height 600 --list --column 'Keyboard Layout' \
   --column '' ${ALLCOLS} \
   --print-column 1 --button gtk-ok \
-  --image /usr/share/icons/Adwaita/48x48/apps/preferences-desktop-keyboard-symbolic.symbolic.png \
+  --image /usr/share/icons/Adwaita/48x48/apps/accessories-character-map-symbolic.symbolic.png \
   --text '{{ potos_firstboot_ask_select_keyboardlayout | default("Please select a keyboard layout") }}')"
 
 if [[ -z "${KEYBOARD_LAYOUT}" ]];

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,6 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-sudo /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
+/usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
 
 echo "${KEYBOARD_LAYOUT}"

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -19,3 +19,4 @@ else
   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 fi
 
+gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &> /dev/null

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,7 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
+/usr/bin/dbus-daemon --session &
 /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
 
 echo "${KEYBOARD_LAYOUT}"

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -13,10 +13,14 @@ KEYBOARD_LAYOUT="$(yad --width 600 --height 600 --list --column 'Keyboard Layout
   --image /usr/share/icons/Adwaita/48x48/apps/accessories-character-map-symbolic.symbolic.png \
   --text '{{ potos_firstboot_ask_select_keyboardlayout | default("Please select a keyboard layout") }}')"
 
-if [[ -z "${KEYBOARD_LAYOUT}" ]]; then
-  echo "us"
-else
-  echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
-fi
+KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 
-gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &> /dev/null
+# if [[ -z "${KEYBOARD_LAYOUT}" ]]; then
+#   echo "us"
+# else
+#   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
+# fi
+
+gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
+
+echo "${KEYBOARD_LAYOUT}" > /tmp/setup_keyboard-layout

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,6 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-sudo /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
+sudo /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
 
-echo "${KEYBOARD_LAYOUT}" > /tmp/setup_keyboard-layout
+echo "${KEYBOARD_LAYOUT}"

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,7 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-rm -rf ~/.cache/dconf && rm -rf ~/.dbus && /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
+/usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
+
 
 echo "${KEYBOARD_LAYOUT}"

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,6 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
+/usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
 
 echo "${KEYBOARD_LAYOUT}" > /tmp/setup_keyboard-layout

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,6 +21,6 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-/usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
+sudo /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]"
 
 echo "${KEYBOARD_LAYOUT}" > /tmp/setup_keyboard-layout

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -21,7 +21,6 @@ KEYBOARD_LAYOUT=$(echo ${KEYBOARD_LAYOUT} | tr -d '|')
 #   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 # fi
 
-/usr/bin/dbus-daemon --session &
-/usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
+rm -rf ~/.cache/dconf && rm -rf ~/.dbus && /usr/bin/gsettings set org.gnome.desktop.input-sources sources "[('xkb', '${KEYBOARD_LAYOUT}')]" &>/tmp/gsettings_xkb
 
 echo "${KEYBOARD_LAYOUT}"

--- a/templates/change-keyboard-layout.j2
+++ b/templates/change-keyboard-layout.j2
@@ -13,8 +13,9 @@ KEYBOARD_LAYOUT="$(yad --width 600 --height 600 --list --column 'Keyboard Layout
   --image /usr/share/icons/Adwaita/48x48/apps/accessories-character-map-symbolic.symbolic.png \
   --text '{{ potos_firstboot_ask_select_keyboardlayout | default("Please select a keyboard layout") }}')"
 
-if [[ -z "${KEYBOARD_LAYOUT}" ]];
+if [[ -z "${KEYBOARD_LAYOUT}" ]]; then
   echo "us"
-then
+else
   echo "$(echo ${KEYBOARD_LAYOUT} | tr -d '|')"
 fi
+


### PR DESCRIPTION
## Description

This PR contains the following working:

- [x] YAD ask hostname, set hostname
- [x] YAD ask new user, if you want this via vars/main.yml
- [x] Delete old "install" user from iso, if you want this via vars/main.yml
- [x] YAD ask & set new disk encryption pw (overwrite: "install").

Commented out, so inactive for now:
- [ ] Change Keyboad Layout, it is still in the .iso hardcoded embedded. Because of the issue `# Error "(process:4037): dconf-WARNING **: 19:01:19.683: failed to commit changes to dconf: The connection is closed"` when set "gsettings" from ansible YAD.
- [ ] GRUB_DEFAULT sed replacement, it is still in the .iso for now.
- [ ] cleanup /setup, it is still in the .iso for now.