### PR TITLE
feat: support configurable secondary groups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,11 +17,15 @@ potos_firstboot_ask_select_keyboardlayout: 'Please select your keyboard layout'
 # Ask Hostname in an extra popup
 potos_firstboot_ask_hostname: true
 
-## Local User Handling
-# Ask to create a new local user, sudo (admin) rights included
-potos_firstboot_local_user_add_with_sudo: true
-# Ask to create local user, without sudo (admin) rights.
-potos_firstboot_local_user_add_without_sudo: false
+## Local User and Group Handling
+# Ask to create a new local user
+potos_firstboot_local_user_add: true
+# List of local groups to create
+potos_firstboot_local_groups: []
+# List of local groups the local user should be added to
+# "sudo" will give full root access via sudo
+potos_firstboot_local_user_groups:
+  - sudo
 # Define its shell, we recommend /bin/bash
 potos_firstboot_local_user_add_shell: /bin/bash
 
@@ -32,7 +36,6 @@ potos_firstboot_initial_user_delete_admin_iso_user: true
 
 # Ask change disk encryption password
 potos_firstboot_ask_change_disk_enc_pw: true
-
 
 # Don't change unless you are not using the Potos playbooks
 potos_firstboot_client_name: "{{ potos_plays_client_short_name | default('potos') }}"

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -30,18 +30,27 @@ argument_specs:
         type: bool
         required: false
         default: true
-      potos_firstboot_local_user_add_with_sudo:
+      potos_firstboot_local_user_add:
         description:
-          - Ask to create a new local user, sudo (admin) rights included
+          - Ask to create a new local user
         type: bool
         required: false
         default: true
-      potos_firstboot_local_user_add_without_sudo:
+      potos_firstboot_local_groups:
         description:
-          - Ask to create a new local user, without sudo (admin) rights.
-        type: bool
+          - Local groups to create
+        type: list
+        elements: str
         required: false
-        default: false
+        default: []
+      potos_firstboot_local_user_groups:
+        description:
+          - Local groups the local user is added to
+        type: list
+        elements: str
+        required: false
+        default:
+          - sudo
       potos_firstboot_local_user_add_shell:
         description:
           - Define the new user shell, we recommend /bin/bash

--- a/tasks/02_user.yml
+++ b/tasks/02_user.yml
@@ -50,26 +50,46 @@
       echo $POTOS_NEW_PASS
   register: potos_new_user_password
   changed_when: false
-  when: potos_firstboot_local_user_add_with_sudo or potos_firstboot_local_user_add_without_sudo
+  when: potos_firstboot_local_user_add
   tags:
     - 'molecule-notest'
 
-- name: Add local user with sudo permission
-  ansible.builtin.user:
-    name: "{{ potos_new_user_password.stdout_lines[0] }}"
-    password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
-    groups: sudo
-    shell: "{{ potos_firstboot_local_user_add_shell }}"
-  when: potos_firstboot_local_user_add_with_sudo
+- name: Add local groups
+  ansible.builtin.group:
+    name: "{{ item }}"
+    system: true
+  loop: "{{ potos_firstboot_local_groups }}"
+  when:
+    - potos_firstboot_local_groups is defined
+    - potos_firstboot_local_groups is iterable
+    - potos_firstboot_local_groups is not string
+    - potos_firstboot_local_groups is not mapping
   tags:
     - 'molecule-notest'
 
-- name: Add local user without sudo permission
+- name: use potos_firstboot_local_user_groups list
+  ansible.builtin.set_fact:
+    potos_firstboot_local_user_groups_list: "{{ potos_firstboot_local_user_groups }}"
+  when:
+    - potos_firstboot_local_user_add
+    - potos_firstboot_local_user_groups is defined
+    - potos_firstboot_local_user_groups is iterable
+    - potos_firstboot_local_user_groups is not string
+    - potos_firstboot_local_user_groups is not mapping
+
+- name: use empty group list, potos_firstboot_local_user_groups unset or invalid
+  ansible.builtin.set_fact:
+    potos_firstboot_local_user_groups_list: []
+  when: potos_firstboot_local_user_groups_list is not defined
+
+- name: Add local user with secondary group memberships
   ansible.builtin.user:
     name: "{{ potos_new_user_password.stdout_lines[0] }}"
     password: "{{ potos_new_user_password.stdout_lines[1] | password_hash('sha512') }}"
+    groups: "{{ potos_firstboot_local_user_groups_list | join(',') }}"
     shell: "{{ potos_firstboot_local_user_add_shell }}"
-  when: potos_firstboot_local_user_add_without_sudo
+  when:
+    - potos_firstboot_local_user_add
   tags:
     - 'molecule-notest'
 
@@ -78,7 +98,7 @@
     name: "{{ potos_firstboot_initial_username.stdout }}"
     state: absent
   when:
-    - potos_new_user_password.stdout_lines[0] != potos_firstboot_initial_username.stdout
     - potos_firstboot_initial_user_delete_admin_iso_user
+    - ( not potos_firstboot_local_user_add or ( potos_new_user_password.stdout_lines[0] != potos_firstboot_initial_username.stdout ) )
   tags:
     - 'molecule-notest'


### PR DESCRIPTION
this commit changes the configurability of the user created by this role.

BREAKING CHANGE

## Description

The creation of local user is now governed by three variables:

`potos_firstboot_local_user_add`: Add a local user or not 
`potos_firstboot_local_groups`: List of groups to create 
`potos_firstboot_local_user_groups`: List of groups to add the user to.

Fixes #15 

## Dependencies

none
